### PR TITLE
Move schema statement definitions to ConnectionAdapter

### DIFF
--- a/lib/activerecord-tenant-level-security.rb
+++ b/lib/activerecord-tenant-level-security.rb
@@ -3,11 +3,11 @@ require 'active_record'
 require 'pg'
 
 require_relative 'activerecord-tenant-level-security/tenant_level_security'
-require_relative 'activerecord-tenant-level-security/migration_extensions'
+require_relative 'activerecord-tenant-level-security/schema_statements'
 require_relative 'activerecord-tenant-level-security/sidekiq'
 
 ActiveSupport.on_load(:active_record) do
-  ActiveRecord::ConnectionAdapters::AbstractAdapter.include TenantLevelSecurity::MigrationExtensions
+  ActiveRecord::ConnectionAdapters::AbstractAdapter.include TenantLevelSecurity::SchemaStatements
 
   ActiveRecord::ConnectionAdapters::AbstractAdapter.set_callback :checkout, :after do |conn|
     TenantLevelSecurity.switch_with_connection!(conn, TenantLevelSecurity.current_tenant_id)

--- a/lib/activerecord-tenant-level-security/schema_statements.rb
+++ b/lib/activerecord-tenant-level-security/schema_statements.rb
@@ -1,5 +1,5 @@
 module TenantLevelSecurity
-  module MigrationExtensions
+  module SchemaStatements
     def create_policy(table_name)
       execute <<~SQL
         ALTER TABLE #{table_name} ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
create_policy, remove_policy を ActiveRecord::Migration ではなく ActiveRecord::ConnectionAdapters::AbstractAdapter のメソッドとして定義することで
connection に対して (create_policy が内部で呼ぶ) execute ではなく create_policy, remove_policy が実行されるようにしました。

ここで呼ばれるメソッドが変わることになります。
https://github.com/rails/rails/blob/35e79f05efad1579c409cdbf6972f4eddcaa18dc/activerecord/lib/active_record/migration.rb#L930-L931
元の実装は create_policy を実行した時に  ActiveRecord::Migration に対して create_policy 内の execute が呼ばれて、ここで method_missing で connection に execute が delegate されていました。
この変更によって create_policy を実行した時に ActiveRecord::Migration に対して create_policy を呼んだ際に method_missing で connection に create_policy が delegate されるようになります。
どちらも内部的には connection の execute が実行されるので動作に影響はないはずです。

これは ActiveRecord::CommandRecorder によって migration を reversible にするための準備です。

また、MigrationExtensions module について以下の gem で同等の処理をしているモジュール名を参考にして SchemaStatements にリネームしました。
https://github.com/scenic-views/scenic
https://github.com/teoljungberg/fx
https://github.com/thoughtbot/paperclip/blob/main/lib/paperclip/schema.rb
https://github.com/alassek/activerecord-pg_enum
