### PR TITLE
Clear query cache after switching

### DIFF
--- a/lib/activerecord-tenant-level-security/tenant_level_security.rb
+++ b/lib/activerecord-tenant-level-security/tenant_level_security.rb
@@ -28,6 +28,8 @@ module TenantLevelSecurity
     end
 
     def switch_with_connection!(conn, tenant_id)
+      conn.clear_query_cache
+
       if tenant_id.present?
         conn.execute("SET tenant_level_security.tenant_id = '#{tenant_id}'")
       else

--- a/spec/activerecord-tenant-level-security/tenant_level_security_spec.rb
+++ b/spec/activerecord-tenant-level-security/tenant_level_security_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe TenantLevelSecurity do
       TenantLevelSecurity.switch!(tenant2.id)
       expect(Employee.all).to contain_exactly(have_attributes(name: 'Tom'))
     end
+
+    context 'with query cache' do
+      it 'clears query cache after switching' do
+        establish_connection(as: :app)
+
+        Employee.connection.enable_query_cache!
+
+        TenantLevelSecurity.switch!(tenant1.id)
+        expect(Employee.all).to contain_exactly(have_attributes(name: 'Jane'))
+
+        TenantLevelSecurity.switch!(tenant2.id)
+        expect(Employee.all).to contain_exactly(have_attributes(name: 'Tom'))
+      end
+    end
   end
 
   describe '.with' do
@@ -47,6 +61,23 @@ RSpec.describe TenantLevelSecurity do
 
       # Back to tenant1
       expect(Employee.all).to contain_exactly(have_attributes(name: 'Jane'))
+    end
+
+    context 'with query cache' do
+      it 'clears query cache after switching' do
+        establish_connection(as: :app)
+
+        Employee.connection.enable_query_cache!
+
+        TenantLevelSecurity.switch!(tenant1.id)
+        expect(Employee.all).to contain_exactly(have_attributes(name: 'Jane'))
+
+        TenantLevelSecurity.with(tenant2.id) do
+          expect(Employee.all).to contain_exactly(have_attributes(name: 'Tom'))
+        end
+
+        expect(Employee.all).to contain_exactly(have_attributes(name: 'Jane'))
+      end
     end
   end
 


### PR DESCRIPTION
[ActiveRecord::ConnectionAdapters::QueryCache](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/QueryCache.html) are caches for each connection based on the query string, so it may return wrong caches after switching.

```ruby
Employee.pluck(:name) # => ["Jane", "Tom"]

ActiveRecord::Base.establish_connection(another_user_config)
Employee.connection.enable_query_cache!

TenantLevelSecurity.with(tenant1.id) do
  Employee.pluck(:name) # => ["Jane"]
  # => SELECT * FROM employees
end

TenantLevelSecurity.with(tenant2.id) do
  # Cache is used!
  Employee.pluck(:name) # => ["Jane"]
end
```

This PR changes the behavior to clear query caches when switching.

This implementation is almost the same as [the operation performed by Active Record](https://github.com/rails/rails/blob/v7.0.4.1/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L21), but does not use `ActiveRecord::Base.clear_query_caches_for_current_thread`. The `switch_with_connection!` Is called when checking out from the connection pool, and at this time, the connection is still inactive:

https://github.com/kufu/activerecord-tenant-level-security/blob/c6274d85c2c50e0a3f4596fb8c5a37551bed36a5/lib/activerecord-tenant-level-security.rb#L19-L21
https://github.com/rails/rails/blob/v7.0.4.1/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L180-L182
https://github.com/rails/rails/blob/v7.0.4.1/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L189-L191

For the above reasons, `clear_query_caches_for_current_thread` does not clear the current connection cache:
https://github.com/rails/rails/blob/v7.0.4.1/activerecord/lib/active_record/connection_handling.rb#L343

However, this method is required to handle multiple connections in a thread when connecting multiple databases. Fortunately, this gem has not yet supported multiple databases, so this is not an issue, but it needs to be taken into account in the future. See also https://github.com/rails/rails/pull/35089