### PR TITLE
Cast current_setting instead of tenant_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ CREATE POLICY tenant_policy ON employees
   AS PERMISSIVE
   FOR ALL
   TO PUBLIC
-  USING (tenant_id::text = current_setting('tenant_level_security.tenant_id'))
-  WITH CHECK (tenant_id::text = current_setting('tenant_level_security.tenant_id'))
+  USING (tenant_id = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::integer)
+  WITH CHECK (tenant_id = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::integer)
 ```
 
 In the table in which the policy is created, only the rows that match the current setting of `tenant_level_security.tenant_id` can be referenced. This value is set by `TenantLevelSecurity.with` etc.

--- a/lib/activerecord-tenant-level-security/schema_statements.rb
+++ b/lib/activerecord-tenant-level-security/schema_statements.rb
@@ -5,13 +5,14 @@ module TenantLevelSecurity
         ALTER TABLE #{table_name} ENABLE ROW LEVEL SECURITY;
         ALTER TABLE #{table_name} FORCE ROW LEVEL SECURITY;
       SQL
+      tenant_id_data_type = get_tenant_id_data_type(table_name)
       execute <<~SQL
         CREATE POLICY tenant_policy ON #{table_name}
           AS PERMISSIVE
           FOR ALL
           TO PUBLIC
-          USING (tenant_id::text = current_setting('tenant_level_security.tenant_id'))
-          WITH CHECK (tenant_id::text = current_setting('tenant_level_security.tenant_id'))
+          USING (tenant_id = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::#{tenant_id_data_type})
+          WITH CHECK (tenant_id = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::#{tenant_id_data_type})
       SQL
     end
 
@@ -23,6 +24,15 @@ module TenantLevelSecurity
       execute <<~SQL
         DROP POLICY tenant_policy ON #{table_name}
       SQL
+    end
+
+    private
+    def get_tenant_id_data_type(table_name)
+      tenant_id_column = columns(table_name)
+        .find{|column| column.name == 'tenant_id'}
+      raise "tenant_id column is missing in #{table_name}" if tenant_id_column.nil?
+
+      tenant_id_column.sql_type
     end
   end
 end

--- a/spec/activerecord-tenant-level-security/tenant_level_security_spec.rb
+++ b/spec/activerecord-tenant-level-security/tenant_level_security_spec.rb
@@ -1,26 +1,49 @@
 RSpec.describe TenantLevelSecurity do
   let(:tenant1) { Tenant.create!(name: 'Tenant1') }
   let(:tenant2) { Tenant.create!(name: 'Tenant2') }
+  let(:uuid_tenant1) { UUIDTenant.create!(name: 'Tenant3') }
+  let(:uuid_tenant2) { UUIDTenant.create!(name: 'Tenant4') }
 
   before do
     Employee.create!(name: 'Jane', tenant: tenant1)
     Employee.create!(name: 'Tom', tenant: tenant2)
+    UUIDEmployee.create!(name: 'Kenny', tenant: uuid_tenant1)
+    UUIDEmployee.create!(name: 'Wendy', tenant: uuid_tenant2)
   end
 
   describe '.switch!' do
-    it 'returns only employees in the switched tenant' do
-      expect(Employee.count).to eq 2
+    context 'with integer tenant_id' do
+      it 'returns only employees in the switched tenant' do
+        expect(Employee.count).to eq 2
 
-      establish_connection(as: :app)
+        establish_connection(as: :app)
 
-      # Nothing is allowed by default
-      expect(Employee.count).to eq 0
+        # Nothing is allowed by default
+        expect(Employee.count).to eq 0
 
-      TenantLevelSecurity.switch!(tenant1.id)
-      expect(Employee.all).to contain_exactly(have_attributes(name: 'Jane'))
+        TenantLevelSecurity.switch!(tenant1.id)
+        expect(Employee.all).to contain_exactly(have_attributes(name: 'Jane'))
 
-      TenantLevelSecurity.switch!(tenant2.id)
-      expect(Employee.all).to contain_exactly(have_attributes(name: 'Tom'))
+        TenantLevelSecurity.switch!(tenant2.id)
+        expect(Employee.all).to contain_exactly(have_attributes(name: 'Tom'))
+      end
+    end
+
+    context 'with uuid tenant_id' do
+      it 'returns only employees in the switched tenant' do
+        expect(UUIDEmployee.count).to eq 2
+
+        establish_connection(as: :app)
+
+        # Nothing is allowed by default
+        expect(UUIDEmployee.count).to eq 0
+
+        TenantLevelSecurity.switch!(uuid_tenant1.id)
+        expect(UUIDEmployee.all).to contain_exactly(have_attributes(name: 'Kenny'))
+
+        TenantLevelSecurity.switch!(uuid_tenant2.id)
+        expect(UUIDEmployee.all).to contain_exactly(have_attributes(name: 'Wendy'))
+      end
     end
 
     context 'with query cache' do

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -1,4 +1,6 @@
 ActiveRecord::Schema.define(version: 1) do
+  enable_extension "pgcrypto"
+  # Create tables for integer tenant_id
   create_table :tenants, force: true do |t|
     t.string :name
   end
@@ -9,6 +11,18 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   create_policy :employees
+
+  # Create tables for uuid tenant_id
+  create_table :uuid_tenants, id: :uuid, force: true do |t|
+    t.string :name
+  end
+
+  create_table :uuid_employees, force: true do |t|
+    t.uuid :tenant_id
+    t.string :name
+  end
+
+  create_policy :uuid_employees
 end
 
 class Tenant < ActiveRecord::Base
@@ -17,4 +31,12 @@ end
 
 class Employee < ActiveRecord::Base
   belongs_to :tenant
+end
+
+class UUIDTenant < ActiveRecord::Base
+  has_many :employees, class_name: 'UUIDEmployee', foreign_key: :tenant_id
+end
+
+class UUIDEmployee < ActiveRecord::Base
+  belongs_to :tenant, class_name: 'UUIDTenant', foreign_key: :tenant_id
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,5 +41,7 @@ RSpec.configure do |config|
     # Delete all fixtures
     Employee.delete_all
     Tenant.delete_all
+    UUIDEmployee.delete_all
+    UUIDTenant.delete_all
   end
 end


### PR DESCRIPTION
This PR allows `create_policy` to cast current_setting instead of tenant_id.  

Before this PR, `qual` and `with_check` casts a tenant_id column.
```
tenant_id::text = current_setting('tenant_level_security.tenant_id')
```

After this PR, `qual` and `with_check` casts `current_setting`
```
tenant_id = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::integer)
```

By casting current_setting, PostgresSQL can estimate more precise cardinality.

We can check this behavior with the following experiment.

```sql
CREATE TABLE IF NOT EXISTS sample (
  tenant_id integer,
  id integer
);

-- Add 1000 rows for tenant_id = 1
INSERT INTO sample (tenant_id, id) VALUES (1, (generate_series(1,1000)));
-- Add 1000 rows for tenant_id = 2
INSERT INTO sample (tenant_id, id) VALUES (2, (generate_series(1,1000)));
ANALYZE sample;
```

### Cast current_setting

```sql
SET tenant_level_security.tenant_id = 1;
explain select  * from sample where tenant_id = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::integer;
```

```
+---------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                  |
|---------------------------------------------------------------------------------------------|
| Seq Scan on sample  (cost=0.00..49.00 rows=1000 width=8)                                    |
|   Filter: (tenant_id = (current_setting('tenant_level_security.tenant_id'::text))::integer) |
+---------------------------------------------------------------------------------------------+
```

rows=1000
=> Good estimation

### Cast tenant_id


```sql


```

```
+------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                               |
|------------------------------------------------------------------------------------------|
| Seq Scan on sample  (cost=0.00..49.00 rows=10 width=8)                                   |
|   Filter: ((tenant_id)::text = current_setting('tenant_level_security.tenant_id'::text)) |
+------------------------------------------------------------------------------------------+
```

rows=10
=> Poor estimation

## Migrating from existing policy
If you're already using activerecord-tenant-level-security, you need to run a migration to update policies.   
This migration would be something like this.

```ruby
class AlterPoicies < ActiveRecord::Migration[7.0]
  TENANT_ID_DATA_TYPE = "[YOUR tenant_id DATA TYPE (ex: integer ]"

  def change
    reversible do |dir|
      dir.up do
        using_and_check = "tenant_id = (NULLIF(current_setting('tenant_level_security.tenant_id'::text), ''::text))::#{TENANT_ID_DATA_TYPE}"
        target_tables.each do |table|
          execute <<-SQL.squish
              ALTER POLICY tenant_policy ON #{table}
                USING (#{using_and_check})
                WITH CHECK (#{using_and_check});
          SQL
        end
      end
      dir.down do
        using_and_check = "tenant_id::text = current_setting('tenant_level_security.tenant_id'::text)"
        target_tables.each do |table|
          execute <<-SQL.squish
              ALTER POLICY tenant_policy ON #{table}
                USING (#{using_and_check})
                WITH CHECK (#{using_and_check});
          SQL
        end
      end
    end
  end

  private

  def target_tables
    result = execute <<-SQL.squish
      SELECT tablename FROM pg_policies WHERE policyname = 'tenant_policy';
    SQL
    result.pluck("tablename")
  end
end
```
