### PR TITLE
Modified the sample code in "Sidekiq Integration" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
     chain.add TenantLevelSecurity::Sidekiq::Middleware::Server
   end
+
+  config.client_middleware do |chain|
+    chain.add TenantLevelSecurity::Sidekiq::Middleware::Client
+  end
 end
 ```
 


### PR DESCRIPTION
To add the client middleware on the server side.

Otherwise, tenant id will not set when the job is enqueued within another job.