### PR TITLE
Enable support for custom column names for tenant-level security policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ class CreateEmployee < ActiveRecord::Migration[6.0]
     create_policy :employees
 
     # You can also use a column other than "tenant_id" by passing the "partition_key" option.
-    # create_policy :employees, partition_key: 'company_id'
+    # create_policy :employees, partition_key: :company_id
+    # And you can also specify the partition key as a string.
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -51,23 +51,11 @@ class CreateEmployee < ActiveRecord::Migration[6.0]
       t.string :name
     end
 
+    # By default, "tenant_id" is used as a partition key.
     create_policy :employees
-  end
-end
-```
 
-By default, this method uses the `tenant_id` column as the partition key.  
-To create a policy using a custom column as the partition key, specify the `partition_key` option as shown below:
-
-```ruby
-class CreateEmployee < ActiveRecord::Migration[6.0]
-  def change
-    create_table :employees do |t|
-      t.integer :company_id
-      t.string :name
-    end
-
-    create_policy :employees, partition_key: 'company_id'
+    # You can also use a column other than "tenant_id" by passing the "partition_key" option.
+    # create_policy :employees, partition_key: 'company_id'
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # activerecord-tenant-level-security
+
 [![CircleCI](https://circleci.com/gh/kufu/activerecord-tenant-level-security/tree/master.svg?style=svg)](https://circleci.com/gh/kufu/activerecord-tenant-level-security/tree/master)
 [![gem-version](https://img.shields.io/gem/v/activerecord-tenant-level-security.svg)](https://rubygems.org/gems/activerecord-tenant-level-security)
 [![License](https://img.shields.io/github/license/kufu/activerecord-tenant-level-security.svg?color=blue)](https://github.com/kufu/activerecord-tenant-level-security/blob/master/LICENSE.txt)
@@ -51,6 +52,22 @@ class CreateEmployee < ActiveRecord::Migration[6.0]
     end
 
     create_policy :employees
+  end
+end
+```
+
+By default, this method uses the `tenant_id` column as the partition key.  
+To create a policy using a custom column as the partition key, specify the `partition_key` option as shown below:
+
+```ruby
+class CreateEmployee < ActiveRecord::Migration[6.0]
+  def change
+    create_table :employees do |t|
+      t.integer :company_id
+      t.string :name
+    end
+
+    create_policy :employees, partition_key: 'company_id'
   end
 end
 ```

--- a/lib/activerecord-tenant-level-security/schema_dumper.rb
+++ b/lib/activerecord-tenant-level-security/schema_dumper.rb
@@ -40,7 +40,11 @@ module TenantLevelSecurity
 
     def convert_qual_to_partition_key(qual)
       matched = qual.match(/^\((.+?) = /)
-      matched ? matched[1] : nil
+      # This error can occur if the specification of the 'tenant_policy' in PostgreSQL
+      #   or the 'create_policy' method changes
+      raise "Failed to parse partition key from 'qual': #{qual}" unless matched
+
+      matched[1]
     end
 
     class Policy

--- a/lib/activerecord-tenant-level-security/schema_dumper.rb
+++ b/lib/activerecord-tenant-level-security/schema_dumper.rb
@@ -55,7 +55,7 @@ module TenantLevelSecurity
 
       def to_schema
         schema = %(  create_policy "#{table_name}")
-        if partition_key && partition_key != TenantLevelSecurity::DEFAULT_PARTITION_KEY
+        if partition_key != TenantLevelSecurity::DEFAULT_PARTITION_KEY
           schema += %(, partition_key: "#{partition_key}")
         end
         schema

--- a/lib/activerecord-tenant-level-security/schema_dumper.rb
+++ b/lib/activerecord-tenant-level-security/schema_dumper.rb
@@ -48,8 +48,6 @@ module TenantLevelSecurity
     end
 
     class Policy
-      DEFAULT_PARTITION_KEY = 'tenant_id'
-
       def initialize(table_name:, partition_key:)
         @table_name = table_name
         @partition_key = partition_key
@@ -57,7 +55,9 @@ module TenantLevelSecurity
 
       def to_schema
         schema = %(  create_policy "#{table_name}")
-        schema += %(, partition_key: "#{partition_key}") if partition_key && partition_key != DEFAULT_PARTITION_KEY
+        if partition_key && partition_key != TenantLevelSecurity::DEFAULT_PARTITION_KEY
+          schema += %(, partition_key: "#{partition_key}")
+        end
         schema
       end
 

--- a/lib/activerecord-tenant-level-security/schema_dumper.rb
+++ b/lib/activerecord-tenant-level-security/schema_dumper.rb
@@ -42,7 +42,7 @@ module TenantLevelSecurity
       matched = qual.match(/^\((.+?) = /)
       # This error can occur if the specification of the 'tenant_policy' in PostgreSQL
       #   or the 'create_policy' method changes
-      raise "Failed to parse partition key from 'qual': #{qual}" unless matched
+      raise "Failed to parse partition key from 'pg_policies.qual': #{qual}" unless matched
 
       matched[1]
     end

--- a/lib/activerecord-tenant-level-security/schema_statements.rb
+++ b/lib/activerecord-tenant-level-security/schema_statements.rb
@@ -28,7 +28,7 @@ module TenantLevelSecurity
 
     private
     def get_tenant_id_data_type(table_name, partition_key)
-      tenant_id_column = columns(table_name).find { |column| column.name == partition_key }
+      tenant_id_column = columns(table_name).find { |column| column.name == partition_key.to_s }
       raise "#{partition_key} column is missing in #{table_name}" if tenant_id_column.nil?
 
       tenant_id_column.sql_type

--- a/lib/activerecord-tenant-level-security/schema_statements.rb
+++ b/lib/activerecord-tenant-level-security/schema_statements.rb
@@ -1,18 +1,18 @@
 module TenantLevelSecurity
   module SchemaStatements
-    def create_policy(table_name, column_name: 'tenant_id')
+    def create_policy(table_name, partition_key: 'tenant_id')
       execute <<~SQL
         ALTER TABLE #{table_name} ENABLE ROW LEVEL SECURITY;
         ALTER TABLE #{table_name} FORCE ROW LEVEL SECURITY;
       SQL
-      tenant_id_data_type = get_tenant_id_data_type(table_name, column_name)
+      tenant_id_data_type = get_tenant_id_data_type(table_name, partition_key)
       execute <<~SQL
         CREATE POLICY tenant_policy ON #{table_name}
           AS PERMISSIVE
           FOR ALL
           TO PUBLIC
-          USING (#{column_name} = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::#{tenant_id_data_type})
-          WITH CHECK (#{column_name} = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::#{tenant_id_data_type})
+          USING (#{partition_key} = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::#{tenant_id_data_type})
+          WITH CHECK (#{partition_key} = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::#{tenant_id_data_type})
       SQL
     end
 
@@ -27,9 +27,9 @@ module TenantLevelSecurity
     end
 
     private
-    def get_tenant_id_data_type(table_name, column_name)
-      tenant_id_column = columns(table_name).find { |column| column.name == column_name }
-      raise "#{column_name} column is missing in #{table_name}" if tenant_id_column.nil?
+    def get_tenant_id_data_type(table_name, partition_key)
+      tenant_id_column = columns(table_name).find { |column| column.name == partition_key }
+      raise "#{partition_key} column is missing in #{table_name}" if tenant_id_column.nil?
 
       tenant_id_column.sql_type
     end

--- a/lib/activerecord-tenant-level-security/schema_statements.rb
+++ b/lib/activerecord-tenant-level-security/schema_statements.rb
@@ -16,7 +16,7 @@ module TenantLevelSecurity
       SQL
     end
 
-    def remove_policy(table_name, _)
+    def remove_policy(table_name, *args)
       execute <<~SQL
         ALTER TABLE #{table_name} NO FORCE ROW LEVEL SECURITY;
         ALTER TABLE #{table_name} DISABLE ROW LEVEL SECURITY;

--- a/lib/activerecord-tenant-level-security/schema_statements.rb
+++ b/lib/activerecord-tenant-level-security/schema_statements.rb
@@ -1,28 +1,31 @@
 module TenantLevelSecurity
   module SchemaStatements
     def create_policy(table_name, partition_key: TenantLevelSecurity::DEFAULT_PARTITION_KEY)
+      quoted_table_name = quote_table_name(table_name)
+      quoted_partition_key = quote_column_name(partition_key)
       execute <<~SQL
-        ALTER TABLE #{table_name} ENABLE ROW LEVEL SECURITY;
-        ALTER TABLE #{table_name} FORCE ROW LEVEL SECURITY;
+        ALTER TABLE #{quoted_table_name} ENABLE ROW LEVEL SECURITY;
+        ALTER TABLE #{quoted_table_name} FORCE ROW LEVEL SECURITY;
       SQL
       tenant_id_data_type = get_tenant_id_data_type(table_name, partition_key)
       execute <<~SQL
-        CREATE POLICY tenant_policy ON #{table_name}
+        CREATE POLICY tenant_policy ON #{quoted_table_name}
           AS PERMISSIVE
           FOR ALL
           TO PUBLIC
-          USING (#{partition_key} = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::#{tenant_id_data_type})
-          WITH CHECK (#{partition_key} = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::#{tenant_id_data_type})
+          USING (#{quoted_partition_key} = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::#{tenant_id_data_type})
+          WITH CHECK (#{quoted_partition_key} = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::#{tenant_id_data_type})
       SQL
     end
 
     def remove_policy(table_name, *args)
+      quoted_table_name = quote_table_name(table_name)
       execute <<~SQL
-        ALTER TABLE #{table_name} NO FORCE ROW LEVEL SECURITY;
-        ALTER TABLE #{table_name} DISABLE ROW LEVEL SECURITY;
+        ALTER TABLE #{quoted_table_name} NO FORCE ROW LEVEL SECURITY;
+        ALTER TABLE #{quoted_table_name} DISABLE ROW LEVEL SECURITY;
       SQL
       execute <<~SQL
-        DROP POLICY tenant_policy ON #{table_name}
+        DROP POLICY tenant_policy ON #{quoted_table_name}
       SQL
     end
 

--- a/lib/activerecord-tenant-level-security/schema_statements.rb
+++ b/lib/activerecord-tenant-level-security/schema_statements.rb
@@ -1,6 +1,6 @@
 module TenantLevelSecurity
   module SchemaStatements
-    def create_policy(table_name, partition_key: 'tenant_id')
+    def create_policy(table_name, partition_key: TenantLevelSecurity::DEFAULT_PARTITION_KEY)
       execute <<~SQL
         ALTER TABLE #{table_name} ENABLE ROW LEVEL SECURITY;
         ALTER TABLE #{table_name} FORCE ROW LEVEL SECURITY;

--- a/lib/activerecord-tenant-level-security/schema_statements.rb
+++ b/lib/activerecord-tenant-level-security/schema_statements.rb
@@ -1,22 +1,22 @@
 module TenantLevelSecurity
   module SchemaStatements
-    def create_policy(table_name)
+    def create_policy(table_name, column_name: 'tenant_id')
       execute <<~SQL
         ALTER TABLE #{table_name} ENABLE ROW LEVEL SECURITY;
         ALTER TABLE #{table_name} FORCE ROW LEVEL SECURITY;
       SQL
-      tenant_id_data_type = get_tenant_id_data_type(table_name)
+      tenant_id_data_type = get_tenant_id_data_type(table_name, column_name)
       execute <<~SQL
         CREATE POLICY tenant_policy ON #{table_name}
           AS PERMISSIVE
           FOR ALL
           TO PUBLIC
-          USING (tenant_id = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::#{tenant_id_data_type})
-          WITH CHECK (tenant_id = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::#{tenant_id_data_type})
+          USING (#{column_name} = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::#{tenant_id_data_type})
+          WITH CHECK (#{column_name} = NULLIF(current_setting('tenant_level_security.tenant_id'), '')::#{tenant_id_data_type})
       SQL
     end
 
-    def remove_policy(table_name)
+    def remove_policy(table_name, _)
       execute <<~SQL
         ALTER TABLE #{table_name} NO FORCE ROW LEVEL SECURITY;
         ALTER TABLE #{table_name} DISABLE ROW LEVEL SECURITY;
@@ -27,10 +27,9 @@ module TenantLevelSecurity
     end
 
     private
-    def get_tenant_id_data_type(table_name)
-      tenant_id_column = columns(table_name)
-        .find{|column| column.name == 'tenant_id'}
-      raise "tenant_id column is missing in #{table_name}" if tenant_id_column.nil?
+    def get_tenant_id_data_type(table_name, column_name)
+      tenant_id_column = columns(table_name).find { |column| column.name == column_name }
+      raise "#{column_name} column is missing in #{table_name}" if tenant_id_column.nil?
 
       tenant_id_column.sql_type
     end

--- a/lib/activerecord-tenant-level-security/tenant_level_security.rb
+++ b/lib/activerecord-tenant-level-security/tenant_level_security.rb
@@ -1,4 +1,6 @@
 module TenantLevelSecurity
+  DEFAULT_PARTITION_KEY = 'tenant_id'.freeze
+
   class << self
     # The current_tenant_id sets the default tenant from the outside.
     # Be sure to register in advance as `TenantLevelSecurity.current_tenant_id { id }` with initializers.

--- a/spec/activerecord-tenant-level-security/command_recorder_spec.rb
+++ b/spec/activerecord-tenant-level-security/command_recorder_spec.rb
@@ -2,30 +2,62 @@ RSpec.describe TenantLevelSecurity::CommandRecorder do
   let(:recorder) { ActiveRecord::Migration::CommandRecorder.new }
 
   describe "#create_poilcy" do
-    it "records create_policy" do
-      recorder.create_policy(:accounts)
+    context "without keyword arguments" do
+      it "records create_policy" do
+        recorder.create_policy(:accounts)
 
-      expect(recorder.commands).to eq([[:create_policy, [:accounts], nil]])
+        expect(recorder.commands).to eq([[:create_policy, [:accounts], nil]])
+      end
+
+      it "reverts create_policy" do
+        recorder.revert { recorder.create_policy(:accounts) }
+
+        expect(recorder.commands).to eq([[:remove_policy, [:accounts]]])
+      end
     end
 
-    it "reverts create_policy" do
-      recorder.revert { recorder.create_policy(:accounts) }
+    context "with keyword arguments" do
+      it "records create_policy" do
+        recorder.create_policy(:accounts, partition_key: "company_id")
 
-      expect(recorder.commands).to eq([[:remove_policy, [:accounts]]])
+        expect(recorder.commands).to eq([[:create_policy, [:accounts, { partition_key: "company_id" }], nil]])
+      end
+
+      it "reverts create_policy" do
+        recorder.revert { recorder.create_policy(:accounts, partition_key: "company_id") }
+
+        expect(recorder.commands).to eq([[:remove_policy, [:accounts, { partition_key: "company_id" }]]])
+      end
     end
   end
 
   describe "#remove_policy" do
-    it "records remove_policy" do
-      recorder.remove_policy(:accounts)
+    context "without keyword arguments" do
+      it "records remove_policy" do
+        recorder.remove_policy(:accounts)
 
-      expect(recorder.commands).to eq([[:remove_policy, [:accounts], nil]])
+        expect(recorder.commands).to eq([[:remove_policy, [:accounts], nil]])
+      end
+
+      it "reverts remove_policy" do
+        recorder.revert { recorder.remove_policy(:accounts) }
+
+        expect(recorder.commands).to eq([[:create_policy, [:accounts]]])
+      end
     end
 
-    it "reverts remove_policy" do
-      recorder.revert { recorder.remove_policy(:accounts) }
+    context "with keyword arguments" do
+      it "records remove_policy" do
+        recorder.remove_policy(:accounts, partition_key: "company_id")
 
-      expect(recorder.commands).to eq([[:create_policy, [:accounts]]])
+        expect(recorder.commands).to eq([[:remove_policy, [:accounts, { partition_key: "company_id" }], nil]])
+      end
+
+      it "reverts remove_policy" do
+        recorder.revert { recorder.remove_policy(:accounts, partition_key: "company_id") }
+
+        expect(recorder.commands).to eq([[:create_policy, [:accounts, { partition_key: "company_id" }]]])
+      end
     end
   end
 end

--- a/spec/activerecord-tenant-level-security/schema_dumper_spec.rb
+++ b/spec/activerecord-tenant-level-security/schema_dumper_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe TenantLevelSecurity::SchemaDumper do
       end
 
       it "outputs create_policy lines" do
-        expect(definition).to be_include("create_policy")
-        expect(definition).to be_include("partition_key: \"company_id\"")
+        expect(definition).to be_include("create_policy \"employees\"\n")
+        expect(definition).to be_include("create_policy \"company_employees\", partition_key: \"company_id\"\n")
       end
     end
   end

--- a/spec/activerecord-tenant-level-security/schema_dumper_spec.rb
+++ b/spec/activerecord-tenant-level-security/schema_dumper_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe TenantLevelSecurity::SchemaDumper do
 
       it "outputs create_policy lines" do
         expect(definition).to be_include("create_policy")
+        expect(definition).to be_include("partition_key: \"company_id\"")
       end
     end
   end

--- a/spec/activerecord-tenant-level-security/tenant_level_security_spec.rb
+++ b/spec/activerecord-tenant-level-security/tenant_level_security_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe TenantLevelSecurity do
     UUIDEmployee.create!(name: 'Wendy', tenant: uuid_tenant2)
     CompanyEmployee.create!(name: 'Alice', company: company1)
     CompanyEmployee.create!(name: 'Bob', company: company2)
+    CompanyTenant.create!(name: 'James', company: company1)
+    CompanyTenant.create!(name: 'Durant', company: company2)
   end
 
   describe '.switch!' do
@@ -51,19 +53,38 @@ RSpec.describe TenantLevelSecurity do
     end
 
     context 'with company_id' do
-      it 'returns only employees in the switched company' do
-        expect(CompanyEmployee.count).to eq 2
+      context 'on company_employees' do
+        it 'returns only employees in the switched company' do
+          expect(CompanyEmployee.count).to eq 2
 
-        establish_connection(as: :app)
+          establish_connection(as: :app)
 
-        # Nothing is allowed by default
-        expect(CompanyEmployee.count).to eq 0
+          # Nothing is allowed by default
+          expect(CompanyEmployee.count).to eq 0
 
-        TenantLevelSecurity.switch!(company1.id)
-        expect(CompanyEmployee.all).to contain_exactly(have_attributes(name: 'Alice'))
+          TenantLevelSecurity.switch!(company1.id)
+          expect(CompanyEmployee.all).to contain_exactly(have_attributes(name: 'Alice'))
 
-        TenantLevelSecurity.switch!(company2.id)
-        expect(CompanyEmployee.all).to contain_exactly(have_attributes(name: 'Bob'))
+          TenantLevelSecurity.switch!(company2.id)
+          expect(CompanyEmployee.all).to contain_exactly(have_attributes(name: 'Bob'))
+        end
+      end
+
+      context 'on company_tenants' do
+        it 'returns only tenants in the switched company' do
+          expect(CompanyTenant.count).to eq 2
+
+          establish_connection(as: :app)
+
+          # Nothing is allowed by default
+          expect(CompanyTenant.count).to eq 0
+
+          TenantLevelSecurity.switch!(company1.id)
+          expect(CompanyTenant.all).to contain_exactly(have_attributes(name: 'James'))
+
+          TenantLevelSecurity.switch!(company2.id)
+          expect(CompanyTenant.all).to contain_exactly(have_attributes(name: 'Durant'))
+        end
       end
     end
 

--- a/spec/activerecord-tenant-level-security/tenant_level_security_spec.rb
+++ b/spec/activerecord-tenant-level-security/tenant_level_security_spec.rb
@@ -3,12 +3,16 @@ RSpec.describe TenantLevelSecurity do
   let(:tenant2) { Tenant.create!(name: 'Tenant2') }
   let(:uuid_tenant1) { UUIDTenant.create!(name: 'Tenant3') }
   let(:uuid_tenant2) { UUIDTenant.create!(name: 'Tenant4') }
+  let(:company1) { Company.create!(name: 'Company1') }
+  let(:company2) { Company.create!(name: 'Company2') }
 
   before do
     Employee.create!(name: 'Jane', tenant: tenant1)
     Employee.create!(name: 'Tom', tenant: tenant2)
     UUIDEmployee.create!(name: 'Kenny', tenant: uuid_tenant1)
     UUIDEmployee.create!(name: 'Wendy', tenant: uuid_tenant2)
+    CompanyEmployee.create!(name: 'Alice', company: company1)
+    CompanyEmployee.create!(name: 'Bob', company: company2)
   end
 
   describe '.switch!' do
@@ -43,6 +47,23 @@ RSpec.describe TenantLevelSecurity do
 
         TenantLevelSecurity.switch!(uuid_tenant2.id)
         expect(UUIDEmployee.all).to contain_exactly(have_attributes(name: 'Wendy'))
+      end
+    end
+
+    context 'with company_id' do
+      it 'returns only employees in the switched company' do
+        expect(CompanyEmployee.count).to eq 2
+
+        establish_connection(as: :app)
+
+        # Nothing is allowed by default
+        expect(CompanyEmployee.count).to eq 0
+
+        TenantLevelSecurity.switch!(company1.id)
+        expect(CompanyEmployee.all).to contain_exactly(have_attributes(name: 'Alice'))
+
+        TenantLevelSecurity.switch!(company2.id)
+        expect(CompanyEmployee.all).to contain_exactly(have_attributes(name: 'Bob'))
       end
     end
 

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 1) do
     t.string :name
   end
 
-  create_policy :company_employees, column_name: 'company_id'
+  create_policy :company_employees, partition_key: 'company_id'
 end
 
 class Tenant < ActiveRecord::Base

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -23,6 +23,18 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   create_policy :uuid_employees
+
+  # Create tables for not tenant_id
+  create_table :companies, force: true do |t|
+    t.string :name
+  end
+
+  create_table :company_employees, force: true do |t|
+    t.integer :company_id
+    t.string :name
+  end
+
+  create_policy :company_employees, column_name: 'company_id'
 end
 
 class Tenant < ActiveRecord::Base
@@ -39,4 +51,12 @@ end
 
 class UUIDEmployee < ActiveRecord::Base
   belongs_to :tenant, class_name: 'UUIDTenant', foreign_key: :tenant_id
+end
+
+class Company < ActiveRecord::Base
+  has_many :employees, class_name: 'CompanyEmployee', foreign_key: :company_id
+end
+
+class CompanyEmployee < ActiveRecord::Base
+  belongs_to :company
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   create_policy :uuid_employees
+  remove_policy :uuid_employees # test remove_policy
+  create_policy :uuid_employees
 
   # Create tables for not tenant_id
   create_table :companies, force: true do |t|

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -36,7 +36,18 @@ ActiveRecord::Schema.define(version: 1) do
     t.string :name
   end
 
-  create_policy :company_employees, partition_key: 'company_id'
+  create_table :company_tenants, force: true do |t|
+    t.integer :company_id
+    t.string :name
+  end
+
+  create_policy :company_employees, partition_key: :company_id
+  remove_policy :company_employees, partition_key: :company_id # test remove_policy
+  create_policy :company_employees, partition_key: :company_id
+
+  create_policy :company_tenants, partition_key: 'company_id'
+  remove_policy :company_tenants # test remove_policy without partition_key
+  create_policy :company_tenants, partition_key: 'company_id'
 end
 
 class Tenant < ActiveRecord::Base
@@ -57,8 +68,13 @@ end
 
 class Company < ActiveRecord::Base
   has_many :employees, class_name: 'CompanyEmployee', foreign_key: :company_id
+  has_many :tenants, class_name: 'CompanyTenant', foreign_key: :company_id
 end
 
 class CompanyEmployee < ActiveRecord::Base
+  belongs_to :company
+end
+
+class CompanyTenant < ActiveRecord::Base
   belongs_to :company
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,5 +45,6 @@ RSpec.configure do |config|
     UUIDTenant.delete_all
     Company.delete_all
     CompanyEmployee.delete_all
+    CompanyTenant.delete_all
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,5 +43,7 @@ RSpec.configure do |config|
     Tenant.delete_all
     UUIDEmployee.delete_all
     UUIDTenant.delete_all
+    Company.delete_all
+    CompanyEmployee.delete_all
   end
 end


### PR DESCRIPTION
## Description

This pull request introduces the ability to specify custom column names for tenant-level security policies within the `TenantLevelSecurity::SchemaStatements` module.

The need for this enhancement is due to potential conflicts with existing `tenant_id` columns in some applications.

For example, a real estate service may already have a tenant table that uses the `tenant_id` column in a different context.

I'm leaving the default column name as `tenant_id` to maintain compatibility with the standard approach of multi-tenant architecture.
I also made sure that the `tenant_level_security.tenant_id` setting remains unchanged to maintain the consistency and intent behind the design principles of multi-tenant architecture.

## Key changes

- Added an optional `column_name` parameter to the `create_policy` method to allow developers to specify a custom column name for tenant identification.