### PR TITLE
[enhancement] tenant_level_security:install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Or install it yourself as:
 
     $ gem install activerecord-tenant-level-security
 
+Next, run the generator:
+
+    rails generate tenant_level_security:install
+
 ## Usage
 
 The activerecord-tenant-level-security provides an API for applying [PostgreSQL Row Level Security](https://www.postgresql.org/docs/current/ddl-rowsecurity.html) (RLS) as follows:

--- a/activerecord-tenant-level-security.gemspec
+++ b/activerecord-tenant-level-security.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pg", ">= 1.0"
 
   spec.add_development_dependency "bundler", ">= 2.0"
+  spec.add_development_dependency "rails"
   spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rspec", ">= 3.0"
 end

--- a/lib/generators/tenant_level_security/USAGE
+++ b/lib/generators/tenant_level_security/USAGE
@@ -1,0 +1,2 @@
+Description:
+    Copies tenant-level-security configuration file to your application's initializer directory.

--- a/lib/generators/tenant_level_security/install_generator.rb
+++ b/lib/generators/tenant_level_security/install_generator.rb
@@ -1,0 +1,11 @@
+module TenantLevelSecurity
+  module Generators
+    class InstallGenerator < ::Rails::Generators::Base
+      source_root File.expand_path("templates", __dir__)
+
+      def copy_initializer_file
+        copy_file "initializer.rb", "config/initializers/tenant_level_security.rb"
+      end
+    end
+  end
+end

--- a/lib/generators/tenant_level_security/templates/initializer.rb
+++ b/lib/generators/tenant_level_security/templates/initializer.rb
@@ -1,0 +1,6 @@
+# Pass current tenant ID to `TenantLevelSecurity.current_tenant_id` block
+# using ActiveSupport::CurrentAttributes, RequestStore, etc...
+# TenantLevelSecurity.current_tenant_id { RequestStore.store[:current_tenant_id] }
+
+# Uncomment this line if you using activerecord-multi-tenant gem.
+# TenantLevelSecurity.current_tenant_id { MultiTenant.current_tenant_id }

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -1,0 +1,23 @@
+require "tmpdir"
+require "rails/generators"
+require "generators/tenant_level_security/install_generator"
+
+RSpec.describe TenantLevelSecurity::Generators::InstallGenerator, type: :generators do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @destination_root = dir
+      example.run
+    end
+  end
+
+  describe "run generator" do
+    subject { described_class.start([], destination_root: @destination_root) }
+
+    let(:path) { "config/initializers/tenant_level_security.rb" }
+
+    it "generated initializer file" do
+      subject
+      expect(File.exist?(File.expand_path(path, @destination_root))).to be true
+    end
+  end
+end


### PR DESCRIPTION
# Motivation
When using this gem, you must first register `TenantLevelSecurity.current_tenante_id`.
I want to make this step easy.

# Changes
Create InstallGenerator.
This Generator copies initializer file.

# Usage
```
rails g tenant_level_security:install
```