### PR TITLE
CI against ruby 3.4, drop ruby 3.1, rails 7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,4 +30,4 @@ workflows:
             parameters:
               ruby: ['ruby:3.2', 'ruby:3.3', 'ruby:3.4']
               rails: ['rails_7.1', 'rails_7.2', 'rails_8.0']
-              postgres: ['postgres:13.16', 'postgres:14.13', 'postgres:15.8', 'postgres:16.4', 'postgres:17.0']
+              postgres: ['postgres:13.21', 'postgres:14.18', 'postgres:15.13', 'postgres:16.9', 'postgres:17.5']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,23 +28,6 @@ workflows:
       - test:
           matrix:
             parameters:
-              ruby: ['ruby:3.1', 'ruby:3.2', 'ruby:3.3']
-              rails: ['rails_7.0', 'rails_7.1', 'rails_7.2', 'rails_8.0']
+              ruby: ['ruby:3.2', 'ruby:3.3', 'ruby:3.4']
+              rails: ['rails_7.1', 'rails_7.2', 'rails_8.0']
               postgres: ['postgres:13.16', 'postgres:14.13', 'postgres:15.8', 'postgres:16.4', 'postgres:17.0']
-            exclude:
-              # Rails 8.0 requires Ruby >= 3.2.0
-              - ruby: 'ruby:3.1'
-                rails: 'rails_8.0'
-                postgres: 'postgres:13.16'
-              - ruby: 'ruby:3.1'
-                rails: 'rails_8.0'
-                postgres: 'postgres:14.13'
-              - ruby: 'ruby:3.1'
-                rails: 'rails_8.0'
-                postgres: 'postgres:15.8'
-              - ruby: 'ruby:3.1'
-                rails: 'rails_8.0'
-                postgres: 'postgres:16.4'
-              - ruby: 'ruby:3.1'
-                rails: 'rails_8.0'
-                postgres: 'postgres:17.0'

--- a/activerecord-tenant-level-security.gemspec
+++ b/activerecord-tenant-level-security.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 7.0"
-  spec.add_dependency "activesupport", ">= 7.0"
+  spec.add_dependency "activerecord", ">= 7.1"
+  spec.add_dependency "activesupport", ">= 7.1"
   spec.add_dependency "pg", ">= 1.0"
 
   spec.add_development_dependency "bundler", ">= 2.0"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 7.0.2"
-
-gemspec path: "../"


### PR DESCRIPTION
- Add ruby 3.4 to the test matrix
- Update PostgreSQL minor version.
- Drop ruby 3.1 and rails 7.1 support (EOL)
