### PR TITLE
Preserve RLS context across automatic reconnections

### DIFF
--- a/lib/activerecord-tenant-level-security.rb
+++ b/lib/activerecord-tenant-level-security.rb
@@ -1,4 +1,5 @@
 require 'active_support'
+require 'active_support/current_attributes'
 require 'active_record'
 require 'pg'
 
@@ -7,9 +8,11 @@ require_relative 'activerecord-tenant-level-security/command_recorder'
 require_relative 'activerecord-tenant-level-security/schema_dumper'
 require_relative 'activerecord-tenant-level-security/schema_statements'
 require_relative 'activerecord-tenant-level-security/sidekiq'
+require_relative 'activerecord-tenant-level-security/reconnectable_adapter'
 
 ActiveSupport.on_load(:active_record) do
   ActiveRecord::ConnectionAdapters::AbstractAdapter.include TenantLevelSecurity::SchemaStatements
+  ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend TenantLevelSecurity::ReconnectableAdapter
   ActiveRecord::Migration::CommandRecorder.include TenantLevelSecurity::CommandRecorder
   ActiveRecord::SchemaDumper.prepend TenantLevelSecurity::SchemaDumper
 
@@ -17,6 +20,6 @@ ActiveSupport.on_load(:active_record) do
   # Make sure that TenantLevelSecurity.current_tenant_id does not depend on database connections.
   # If a new connection is needed to get the current_tenant_id, the callback may be invoked recursively.
   ActiveRecord::ConnectionAdapters::AbstractAdapter.set_callback :checkout, :after do |conn|
-    TenantLevelSecurity.switch_with_connection!(conn, TenantLevelSecurity.current_tenant_id)
+    TenantLevelSecurity.switch_current_tenant_context!(conn)
   end
 end

--- a/lib/activerecord-tenant-level-security/reconnectable_adapter.rb
+++ b/lib/activerecord-tenant-level-security/reconnectable_adapter.rb
@@ -1,0 +1,9 @@
+module TenantLevelSecurity
+  module ReconnectableAdapter
+    def configure_connection
+      super
+
+      TenantLevelSecurity.switch_current_tenant_context!(self)
+    end
+  end
+end

--- a/lib/activerecord-tenant-level-security/tenant_level_security.rb
+++ b/lib/activerecord-tenant-level-security/tenant_level_security.rb
@@ -1,6 +1,19 @@
 module TenantLevelSecurity
   DEFAULT_PARTITION_KEY = 'tenant_id'.freeze
 
+  class TenantContext < ActiveSupport::CurrentAttributes
+    attribute :tenant_id
+
+    def tenant_id=(val)
+      super
+      TenantLevelSecurity.switch_with_connection!(ActiveRecord::Base.connection, val)
+    end
+
+    resets do
+      TenantLevelSecurity.switch_with_connection!(ActiveRecord::Base.connection, nil)
+    end
+  end
+
   class << self
     # The current_tenant_id sets the default tenant from the outside.
     # Be sure to register in advance as `TenantLevelSecurity.current_tenant_id { id }` with initializers.
@@ -14,19 +27,19 @@ module TenantLevelSecurity
       end
     end
 
-    def with(tenant_id)
-      old_tenant_id = current_session_tenant_id
-      return yield if old_tenant_id == tenant_id
-      begin
-        switch! tenant_id
-        yield
-      ensure
-        switch! old_tenant_id
-      end
+    def with(tenant_id, &block)
+      TenantContext.with(tenant_id: tenant_id, &block)
     end
 
     def switch!(tenant_id)
-      switch_with_connection!(ActiveRecord::Base.connection, tenant_id)
+      TenantContext.tenant_id = tenant_id
+    end
+
+    def switch_current_tenant_context!(conn = ActiveRecord::Base.connection)
+      TenantLevelSecurity.switch_with_connection!(
+        conn,
+        TenantLevelSecurity::TenantContext.tenant_id || TenantLevelSecurity.current_tenant_id
+      )
     end
 
     def switch_with_connection!(conn, tenant_id)

--- a/spec/activerecord-tenant-level-security/tenant_level_security_spec.rb
+++ b/spec/activerecord-tenant-level-security/tenant_level_security_spec.rb
@@ -17,6 +17,20 @@ RSpec.describe TenantLevelSecurity do
     CompanyTenant.create!(name: 'Durant', company: company2)
   end
 
+  describe TenantLevelSecurity::TenantContext do
+    context "on reset" do
+      it "resets RLS context to default" do
+        establish_connection(as: :app)
+
+        TenantLevelSecurity.switch!(tenant1.id)
+        expect(TenantLevelSecurity.current_session_tenant_id).to eq(tenant1.id.to_s)
+
+        TenantLevelSecurity::TenantContext.reset
+        expect(TenantLevelSecurity.current_session_tenant_id).to eq ''
+      end
+    end
+  end
+
   describe '.switch!' do
     context 'with integer tenant_id' do
       it 'returns only employees in the switched tenant' do
@@ -142,6 +156,35 @@ RSpec.describe TenantLevelSecurity do
         end
 
         expect(Employee.all).to contain_exactly(have_attributes(name: 'Jane'))
+      end
+    end
+
+    context "with connection reconnection" do
+      def remote_disconnect(connection)
+        # Connection was left in a bad state, need to reconnect to simulate fresh disconnect
+        connection.verify! if connection.instance_variable_get(:@raw_connection).status == ::PG::CONNECTION_BAD
+        unless connection.instance_variable_get(:@raw_connection).transaction_status == ::PG::PQTRANS_INTRANS
+          connection.instance_variable_get(:@raw_connection).async_exec("begin")
+        end
+        connection.instance_variable_get(:@raw_connection).async_exec("set idle_in_transaction_session_timeout = '10ms'")
+        sleep 0.05
+      end
+
+      it "set current tenant id" do
+        establish_connection(as: :app)
+
+        TenantLevelSecurity.with(tenant1.id) do
+          remote_disconnect(ActiveRecord::Base.connection)
+          expect(Employee.all).to contain_exactly(have_attributes(name: 'Jane'))
+        end
+
+        TenantLevelSecurity.with(tenant2.id) do
+          remote_disconnect(ActiveRecord::Base.connection)
+          expect(Employee.all).to contain_exactly(have_attributes(name: 'Tom'))
+        end
+
+        remote_disconnect(ActiveRecord::Base.connection)
+        expect(Employee.count).to eq 0
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,13 @@ end
 RSpec.configure do |config|
   config.include Helpers
 
+  config.around do |ex|
+    ActiveSupport::CurrentAttributes.clear_all
+    ex.run
+  ensure
+    ActiveSupport::CurrentAttributes.clear_all
+  end
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 


### PR DESCRIPTION
Recent Rails versions automatically reconnect and retry idempotent queries
when a connection is interrupted (https://github.com/rails/rails/pull/51336).

When using RLS, a disconnect clears the session variable
`tenant_level_security.tenant_id`. As a result, queries retried after
reconnection may run without the expected RLS context.

This change fixes the issue by restoring tenant context so RLS continues
to work correctly after reconnection.

Note: the last switched `tenant_id` is now stored in `CurrentAttributes`.
If you use RLS outside Rails, you must call `CurrentAttributes.reset_all`
yourself to avoid stale context.