### PR TITLE
Upgrade PostgreSQL versions in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,4 +30,4 @@ workflows:
             parameters:
               ruby: ['ruby:3.3', 'ruby:3.4', 'ruby:4.0']
               rails: ['rails_7.2', 'rails_8.0', 'rails_8.1']
-              postgres: ['postgres:14.20', 'postgres:15.15', 'postgres:16.11', 'postgres:17.7', 'postgres:18.1']
+              postgres: ['postgres:14.23', 'postgres:15.18', 'postgres:16.14', 'postgres:17.10', 'postgres:18.4']


### PR DESCRIPTION
- Upgraded postgresql version to use the latest version of [cimg/postgres](https://hub.docker.com/r/cimg/postgres)